### PR TITLE
Create zh_cn.json

### DIFF
--- a/src/main/resources/assets/pockettools/lang/zh_cn.json
+++ b/src/main/resources/assets/pockettools/lang/zh_cn.json
@@ -1,0 +1,15 @@
+{
+	"itemGroup.pockettools.pockettools": "便携工具",
+	"item.pockettools.pocket_furnace": "便携熔炉",
+	"item.pockettools.pocket_blast_furnace": "便携高炉",
+	"item.pockettools.pocket_smoker": "便携烟熏炉",
+	"item.pockettools.pocket_grindstone": "便携砂轮",
+	"item.pockettools.pocket_composter": "便携堆肥桶",
+	"item.pockettools.pocket_end_portal": "便携末地门",
+	"item.pockettools.pocket_note_block": "便携音符盒",
+	"item.pockettools.pocket_jukebox": "便携唱片机",
+	"item.pockettools.pocket_armor_stand": "便携盔甲架",
+	"item.pockettools.pocket_cactus": "便携仙人掌",
+	"item.pockettools.pocket_stonecutter": "便携切石机",
+	"item.pockettools.pocket_ender_chest": "便携末影箱"
+}


### PR DESCRIPTION
Cool mod, must be a banger!

To other English-Chinese translators: "末地门"(abbreviation of "end portal") is here to differentiate between "末地传送门框架"(end portal frame) and "末地传送门"(end portal), since they share the name in this mod. It also fits in the idea of "convenient": less characters, straight to the point.